### PR TITLE
Fix NullPointerException in PlayerActivity

### DIFF
--- a/app/src/main/java/com/downloadanysong/dev/prateek/musicplayerdas/NavBar/PlayerActivity.java
+++ b/app/src/main/java/com/downloadanysong/dev/prateek/musicplayerdas/NavBar/PlayerActivity.java
@@ -650,7 +650,7 @@ public class PlayerActivity extends Fragment implements android.media.MediaPlaye
      */
     public void playSong(int songIndex) {
 
-            Intent intent = new Intent(getActivity(), PlayerService.class);
+            Intent intent = new Intent(getContext(), PlayerService.class);
             Log.d("TEST", "PLAY FUNCTION");
             main.setCurrentSongIndex(songIndex);
             intent.setAction(PLAY_ACTION);


### PR DESCRIPTION
The application would stop working if it was closed in the Music Library and then reopened.